### PR TITLE
Add Ternary support to AutoConvert

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puzzle-lib",
-  "version": "1.4.1",
+  "version": "1.4.0",
   "description": "Library of puzzle-solving algorithms",
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puzzle-lib",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Library of puzzle-solving algorithms",
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",

--- a/src/Conversion/CharacterAutoConvert.ts
+++ b/src/Conversion/CharacterAutoConvert.ts
@@ -94,13 +94,13 @@ export class CharacterAutoConvert {
     return CharacterEncoding.None;
   }
 
-  private static readonly BINARY_REGEX = new RegExp('^[01]+$')
+  private static readonly BINARY_REGEX = new RegExp('^[01]+$');
 
   private static appearsBinary(str: string): boolean {
     return this.BINARY_REGEX.test(str);
   }
 
-  private static readonly TERNARY_REGEX = new RegExp('^[0-2]{3}$')
+  private static readonly TERNARY_REGEX = new RegExp('^[0-2]{3}$');
 
   private static appearsTernary(str: string): boolean {
     return this.TERNARY_REGEX.test(str);

--- a/src/Conversion/CharacterAutoConvert.ts
+++ b/src/Conversion/CharacterAutoConvert.ts
@@ -46,6 +46,11 @@ export class CharacterAutoConvert {
       return CharacterAutoConvert.asciiPrintable(binary);
     }
 
+    if (encoding === CharacterEncoding.Ternary) {
+      const ternary = Number.parseInt(input, 3);
+      return CharacterAutoConvert.asciiPrintable(ternary + asciiOffset);
+    }
+
     return '';
   }
 
@@ -71,6 +76,10 @@ export class CharacterAutoConvert {
       }
     }
 
+    if (this.appearsTernary(input)) {
+      return CharacterEncoding.Ternary;
+    }
+
     if (input.length < 3 && numeric > 0 && numeric < 27) {
       return CharacterEncoding.Ordinal;
     }
@@ -85,12 +94,15 @@ export class CharacterAutoConvert {
     return CharacterEncoding.None;
   }
 
-  private static appearsBinary(character: string) {
-    for (const letter of character) {
-      if (letter !== '0' && letter !== '1') {
-        return false;
-      }
-    }
-    return true;
+  private static readonly BINARY_REGEX = new RegExp('^[01]+$')
+
+  private static appearsBinary(str: string): boolean {
+    return this.BINARY_REGEX.test(str);
+  }
+
+  private static readonly TERNARY_REGEX = new RegExp('^[0-2]{3}$')
+
+  private static appearsTernary(str: string): boolean {
+    return this.TERNARY_REGEX.test(str);
   }
 }

--- a/src/Conversion/CharacterEncoding.ts
+++ b/src/Conversion/CharacterEncoding.ts
@@ -5,4 +5,5 @@ export enum CharacterEncoding {
   FiveBitBinary, // 00001 = A, 00010 = B
   EightBitBinary, // 01100001 = A, 01100010 = B
   Ascii, // 65 = A, 66 = B
+  Ternary, // 001 = A, 010 = C, 200 = R
 }

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -23,7 +23,9 @@ describe('Conversions', () => {
       );
       assert.strictEqual(variedSpacing, CharacterEncoding.FiveBitBinary);
 
-      const ternary = StringAutoConvert.determineStringEncoding('100 120 222 001');
+      const ternary = StringAutoConvert.determineStringEncoding(
+        '100 120 222 001'
+      );
       assert.strictEqual(ternary, CharacterEncoding.Ternary);
 
       const none = StringAutoConvert.determineStringEncoding('999 999 999');
@@ -55,9 +57,7 @@ describe('Conversions', () => {
       );
       assert.strictEqual('PLANET', planet);
 
-      const fooTernary = StringAutoConvert.convertString(
-        '020 120 120', true
-      );
+      const fooTernary = StringAutoConvert.convertString('020 120 120', true);
       assert.strictEqual('FOO', fooTernary);
     });
 
@@ -175,7 +175,7 @@ describe('Conversions', () => {
         '11',
         CharacterEncoding.Ternary
       );
-      assert.strictEqual(ternaryD, 'D')
+      assert.strictEqual(ternaryD, 'D');
 
       const eightBitD = CharacterAutoConvert.convertCharacter(
         '1000100',

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -23,6 +23,9 @@ describe('Conversions', () => {
       );
       assert.strictEqual(variedSpacing, CharacterEncoding.FiveBitBinary);
 
+      const ternary = StringAutoConvert.determineStringEncoding('100 120 222 001');
+      assert.strictEqual(ternary, CharacterEncoding.Ternary);
+
       const none = StringAutoConvert.determineStringEncoding('999 999 999');
       assert.strictEqual(none, CharacterEncoding.None);
 
@@ -51,6 +54,11 @@ describe('Conversions', () => {
         true
       );
       assert.strictEqual('PLANET', planet);
+
+      const fooTernary = StringAutoConvert.convertString(
+        '020 120 120', true
+      );
+      assert.strictEqual('FOO', fooTernary);
     });
 
     it('convertString - varied encoding', () => {
@@ -58,7 +66,7 @@ describe('Conversions', () => {
       assert.strictEqual('', noEncoding);
 
       const express = StringAutoConvert.convertString(
-        '01000101 24 16 10010 5    SS',
+        '01000101 24 121 10010 5    SS',
         false
       );
       assert.strictEqual('EXPRESS', express);
@@ -75,6 +83,9 @@ describe('Conversions', () => {
 
       const fiveBit = CharacterAutoConvert.determineCharacterEncoding('01100');
       assert.strictEqual(fiveBit, CharacterEncoding.FiveBitBinary);
+
+      const ternary = CharacterAutoConvert.determineCharacterEncoding('011');
+      assert.strictEqual(ternary, CharacterEncoding.Ternary);
 
       const eightBit = CharacterAutoConvert.determineCharacterEncoding(
         '01101100'
@@ -94,9 +105,9 @@ describe('Conversions', () => {
     });
 
     it('determineCharacterEncoding - Ambigious Cases', () => {
-      // Overlap between ascii and binary
+      // Overlap between ascii and binary and ternary
       const asciiE = CharacterAutoConvert.determineCharacterEncoding('101');
-      assert.strictEqual(asciiE, CharacterEncoding.Ascii);
+      assert.strictEqual(asciiE, CharacterEncoding.Ternary);
 
       // Overlap between ascii and binary
       const binaryE = CharacterAutoConvert.determineCharacterEncoding('00101');
@@ -129,6 +140,12 @@ describe('Conversions', () => {
       const eightBitZ = CharacterAutoConvert.convertCharacter('01011010');
       assert.strictEqual(eightBitZ, 'Z');
 
+      const ternaryA = CharacterAutoConvert.convertCharacter('001');
+      assert.strictEqual(ternaryA, 'A');
+
+      const ternaryZ = CharacterAutoConvert.convertCharacter('222');
+      assert.strictEqual(ternaryZ, 'Z');
+
       const eightBitTruncatedC = CharacterAutoConvert.convertCharacter(
         '1000011'
       );
@@ -153,6 +170,12 @@ describe('Conversions', () => {
         CharacterEncoding.FiveBitBinary
       );
       assert.strictEqual(fiveBitD, 'D');
+
+      const ternaryD = CharacterAutoConvert.convertCharacter(
+        '11',
+        CharacterEncoding.Ternary
+      );
+      assert.strictEqual(ternaryD, 'D')
 
       const eightBitD = CharacterAutoConvert.convertCharacter(
         '1000100',


### PR DESCRIPTION
This adds support for Ternary to the AutoConvert tool.  Consumers which use StringConverter will get this for free without any code changes (other than picking up a new puzzle-lib version).

![image](https://user-images.githubusercontent.com/2019044/94762106-ad570280-035b-11eb-82b2-cc27d65cc177.png)

Fixes #124 