### PR TITLE
Update build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 10.x
           - 12.x
           - 14.x
-          - 15.x
+          - 16.x
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
- Remove 10.x (already end-of-life)
- Remove 15.x (end-of-life on 6/1/2021)
- Add 16.x (upcoming LTS version)