### PR TITLE
Make sure *.js and *.ts files use LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
-* text=auto
+*     text=auto
+*.js  text eol=lf
+*.ts  text eol=lf


### PR DESCRIPTION
On a fresh clone the files ended up with CRLF line endings which the
Prettier tool does not like. Force them to use LF instead.
