### PR TITLE
Export named ResistorColors constants

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -288,18 +288,14 @@ Resistor color code calculator.
 import {
   getResistorDisplayValue,
   getResistorValue,
-  hasResistorTolerance,
-  hasResistorValue,
-  INVALID_RESISTOR,
-  RESISTOR_COLOR_TABLE,
+  ResistorColors,
 } from 'puzzle-lib/resistor';
-import type {ResistorColor} from 'puzzle-lib/resistor';
 
-// Calculate resistance from color bands
+// Calculate resistance from color bands using named constants
 const value = getResistorValue([
-  RESISTOR_COLOR_TABLE[4], // Yellow
-  RESISTOR_COLOR_TABLE[7], // Violet
-  RESISTOR_COLOR_TABLE[3], // Orange (multiplier)
+  ResistorColors.Yellow,
+  ResistorColors.Violet,
+  ResistorColors.Orange, // multiplier
 ]);
 getResistorDisplayValue(value); // '47k'
 ```
@@ -312,6 +308,7 @@ getResistorDisplayValue(value); // '47k'
 | `hasResistorTolerance(color)`    | Function | Check if a color has a tolerance value               |
 | `INVALID_RESISTOR`               | Constant | Sentinel value for invalid resistor                  |
 | `RESISTOR_COLOR_TABLE`           | Constant | Full color code reference table                      |
+| `ResistorColors`                 | Constant | Named color constants (e.g., `ResistorColors.Yellow`) |
 | `ResistorColor`                  | Type     | A resistor color band entry                          |
 
 ## `puzzle-lib/semaphore`

--- a/src/resistor/index.ts
+++ b/src/resistor/index.ts
@@ -5,5 +5,6 @@ export {
   hasResistorValue,
   INVALID_RESISTOR,
   RESISTOR_COLOR_TABLE,
+  ResistorColors,
 } from './resistor.js';
 export type {ResistorColor} from './resistor.js';

--- a/src/resistor/resistor.ts
+++ b/src/resistor/resistor.ts
@@ -56,6 +56,22 @@ export const RESISTOR_COLOR_TABLE: readonly ResistorColor[] = [
   },
 ] as const;
 
+/** Named resistor color constants for self-documenting band selection. */
+export const ResistorColors = {
+  Black: RESISTOR_COLOR_TABLE[0],
+  Brown: RESISTOR_COLOR_TABLE[1],
+  Red: RESISTOR_COLOR_TABLE[2],
+  Orange: RESISTOR_COLOR_TABLE[3],
+  Yellow: RESISTOR_COLOR_TABLE[4],
+  Green: RESISTOR_COLOR_TABLE[5],
+  Blue: RESISTOR_COLOR_TABLE[6],
+  Violet: RESISTOR_COLOR_TABLE[7],
+  Grey: RESISTOR_COLOR_TABLE[8],
+  White: RESISTOR_COLOR_TABLE[9],
+  Gold: RESISTOR_COLOR_TABLE[10],
+  Silver: RESISTOR_COLOR_TABLE[11],
+} as const;
+
 export const INVALID_RESISTOR = -1;
 
 function applyMultiplier(value: number, multiplier: number): number {

--- a/test/resistor.ts
+++ b/test/resistor.ts
@@ -2,31 +2,27 @@ import {describe, it, expect} from 'vitest';
 import {
   RESISTOR_COLOR_TABLE,
   INVALID_RESISTOR,
+  ResistorColors,
   getResistorValue,
   getResistorDisplayValue,
   hasResistorValue,
   hasResistorTolerance,
 } from '../src/resistor/index.js';
 
-// Helper to look up colors by name
-function color(name: string) {
-  const entry = RESISTOR_COLOR_TABLE.find(c => c.name === name);
-  if (!entry) throw new Error(`Unknown color: ${name}`);
-  return entry;
-}
-
-const BLACK = color('Black');
-const BROWN = color('Brown');
-const RED = color('Red');
-const ORANGE = color('Orange');
-const YELLOW = color('Yellow');
-const GREEN = color('Green');
-const BLUE = color('Blue');
-const VIOLET = color('Violet');
-const GREY = color('Grey');
-const WHITE = color('White');
-const GOLD = color('Gold');
-const SILVER = color('Silver');
+const {
+  Black: BLACK,
+  Brown: BROWN,
+  Red: RED,
+  Orange: ORANGE,
+  Yellow: YELLOW,
+  Green: GREEN,
+  Blue: BLUE,
+  Violet: VIOLET,
+  Grey: GREY,
+  White: WHITE,
+  Gold: GOLD,
+  Silver: SILVER,
+} = ResistorColors;
 
 describe('Resistor', () => {
   it('Valid 3 Color Resistors', () => {
@@ -94,5 +90,20 @@ describe('Resistor', () => {
     expect(getResistorDisplayValue(1200)).toBe('1.2k');
     expect(getResistorDisplayValue(30000000)).toBe('30M');
     expect(getResistorDisplayValue(45900000000)).toBe('45.9G');
+  });
+
+  it('ResistorColors matches RESISTOR_COLOR_TABLE entries', () => {
+    expect(ResistorColors.Black).toBe(RESISTOR_COLOR_TABLE[0]);
+    expect(ResistorColors.Brown).toBe(RESISTOR_COLOR_TABLE[1]);
+    expect(ResistorColors.Red).toBe(RESISTOR_COLOR_TABLE[2]);
+    expect(ResistorColors.Orange).toBe(RESISTOR_COLOR_TABLE[3]);
+    expect(ResistorColors.Yellow).toBe(RESISTOR_COLOR_TABLE[4]);
+    expect(ResistorColors.Green).toBe(RESISTOR_COLOR_TABLE[5]);
+    expect(ResistorColors.Blue).toBe(RESISTOR_COLOR_TABLE[6]);
+    expect(ResistorColors.Violet).toBe(RESISTOR_COLOR_TABLE[7]);
+    expect(ResistorColors.Grey).toBe(RESISTOR_COLOR_TABLE[8]);
+    expect(ResistorColors.White).toBe(RESISTOR_COLOR_TABLE[9]);
+    expect(ResistorColors.Gold).toBe(RESISTOR_COLOR_TABLE[10]);
+    expect(ResistorColors.Silver).toBe(RESISTOR_COLOR_TABLE[11]);
   });
 });


### PR DESCRIPTION
Adds a `ResistorColors` object with named properties (e.g., `ResistorColors.Yellow`, `ResistorColors.Violet`) that directly reference the corresponding `RESISTOR_COLOR_TABLE` entries.

**Before:**
```ts
const value = getResistorValue([
  RESISTOR_COLOR_TABLE[4], // Yellow
  RESISTOR_COLOR_TABLE[7], // Violet
  RESISTOR_COLOR_TABLE[3], // Orange
]);
```

**After:**
```ts
const value = getResistorValue([
  ResistorColors.Yellow,
  ResistorColors.Violet,
  ResistorColors.Orange,
]);
```

- `RESISTOR_COLOR_TABLE` is preserved for iteration (dropdowns, reference tables)
- Tests updated to use `ResistorColors` instead of runtime `find()` lookups
- Added test verifying `ResistorColors` entries match `RESISTOR_COLOR_TABLE` indices
- Updated `docs/API.md` with new example and export table entry

Fixes #187