### PR TITLE
Add text-to-encoding functions for morse, braille, pigpen, and semaphore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puzzle-lib",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "description": "Library of puzzle-solving algorithms",
   "type": "module",
   "exports": {

--- a/src/braille/braille.ts
+++ b/src/braille/braille.ts
@@ -150,6 +150,20 @@ export function getBrailleDot(
 }
 
 /**
+ * Encodes plain text to an array of braille encodings.
+ * Unknown characters map to BrailleEncoding.None.
+ */
+export function encodeBrailleStream(text: string): BrailleEncoding[] {
+  return text
+    .toUpperCase()
+    .split('')
+    .map(ch => {
+      const entry = BRAILLE_ENTRIES.find(e => e.display === ch);
+      return entry ? entry.encoding : BrailleEncoding.None;
+    });
+}
+
+/**
  * Decodes an array of braille encodings to a string, handling number mode.
  */
 export function decodeBrailleStream(encodings: BrailleEncoding[]): string {

--- a/src/braille/index.ts
+++ b/src/braille/index.ts
@@ -1,5 +1,6 @@
 export {
   decodeBrailleStream,
+  encodeBrailleStream,
   getBrailleDot,
   lookupBrailleEncoding,
   toggleBrailleDot,

--- a/src/morse/index.ts
+++ b/src/morse/index.ts
@@ -1,5 +1,6 @@
 export {
   decodeMorse,
+  encodeMorse,
   invertAndReverseMorse,
   invertMorse,
   lookupMorseEncoding,

--- a/src/morse/morse.ts
+++ b/src/morse/morse.ts
@@ -292,6 +292,29 @@ export function reverseMorse(
 }
 
 /**
+ * Encodes plain text to a morse string.
+ */
+export function encodeMorse(
+  text: string,
+  characterDivider = MORSE_CHARACTER_DIVIDER,
+  wordDivider = MORSE_WORD_DIVIDER,
+): string {
+  validateDividers(characterDivider, wordDivider);
+  const words = text.toUpperCase().split(' ');
+  return words
+    .map(word =>
+      word
+        .split('')
+        .map(ch => {
+          const entry = MORSE_ENTRIES.find(e => e.display === ch);
+          return entry ? morseEncodingToString(entry.encoding) : '?';
+        })
+        .join(characterDivider),
+    )
+    .join(wordDivider);
+}
+
+/**
  * Inverts dots/dashes and reverses a morse string, then decodes.
  */
 export function invertAndReverseMorse(

--- a/src/pigpen/index.ts
+++ b/src/pigpen/index.ts
@@ -1,6 +1,7 @@
 export {
   canTogglePigpenSegment,
   decodePigpenStream,
+  encodePigpenStream,
   hasPigpenSegment,
   isCardinal,
   isIntercardinal,

--- a/src/pigpen/pigpen.ts
+++ b/src/pigpen/pigpen.ts
@@ -148,6 +148,20 @@ export function canTogglePigpenSegment(
 }
 
 /**
+ * Encodes plain text to an array of pigpen encodings.
+ * Unknown characters map to PigpenEncoding.None.
+ */
+export function encodePigpenStream(text: string): PigpenEncoding[] {
+  return text
+    .toUpperCase()
+    .split('')
+    .map(ch => {
+      const entry = PIGPEN_ENTRIES.find(e => e.display === ch);
+      return entry ? entry.encoding : PigpenEncoding.None;
+    });
+}
+
+/**
  * Decodes an array of pigpen encodings to a string.
  */
 export function decodePigpenStream(encodings: PigpenEncoding[]): string {

--- a/src/semaphore/index.ts
+++ b/src/semaphore/index.ts
@@ -1,6 +1,7 @@
 export {
   addSemaphoreDirection,
   decodeSemaphoreStream,
+  encodeSemaphoreStream,
   degreesToSemaphoreDirection,
   directionsToEncoding,
   getEncodingDegrees,

--- a/src/semaphore/semaphore.ts
+++ b/src/semaphore/semaphore.ts
@@ -223,6 +223,20 @@ export function getEncodingDegrees(
 }
 
 /**
+ * Encodes plain text to an array of semaphore encodings.
+ * Unknown characters map to SemaphoreEncoding.None.
+ */
+export function encodeSemaphoreStream(text: string): SemaphoreEncoding[] {
+  return text
+    .toUpperCase()
+    .split('')
+    .map(ch => {
+      const entry = SEMAPHORE_ENTRIES.find(e => e.display === ch);
+      return entry ? entry.encoding : SemaphoreEncoding.None;
+    });
+}
+
+/**
  * Decodes an array of semaphore encodings to a string, handling number mode.
  */
 export function decodeSemaphoreStream(encodings: SemaphoreEncoding[]): string {

--- a/test/braille.ts
+++ b/test/braille.ts
@@ -3,6 +3,7 @@ import {EncodingCategory} from '../src/common/index.js';
 import {
   BrailleDot,
   BrailleEncoding,
+  encodeBrailleStream,
   lookupBrailleEncoding,
   toggleBrailleDot,
   getBrailleDot,
@@ -134,6 +135,22 @@ describe('Braille', () => {
       encodings.push(BrailleEncoding.None);
       encodings.push(BrailleEncoding.LetterD);
       expect(decodeBrailleStream(encodings)).toBe('#123 D');
+    });
+
+    it('encodeBrailleStream basic', () => {
+      expect(encodeBrailleStream('ABC')).toEqual([
+        BrailleEncoding.LetterA,
+        BrailleEncoding.LetterB,
+        BrailleEncoding.LetterC,
+      ]);
+    });
+
+    it('encodeBrailleStream unknown character becomes None', () => {
+      expect(encodeBrailleStream('A~B')).toEqual([
+        BrailleEncoding.LetterA,
+        BrailleEncoding.None,
+        BrailleEncoding.LetterB,
+      ]);
     });
 
     it('copy independence', () => {

--- a/test/morse.ts
+++ b/test/morse.ts
@@ -1,6 +1,7 @@
 import {describe, it, expect} from 'vitest';
 import {
   decodeMorse,
+  encodeMorse,
   invertMorse,
   reverseMorse,
   invertAndReverseMorse,
@@ -116,6 +117,31 @@ describe('Morse', () => {
   describe('invertAndReverseMorse', () => {
     it('Basic', () => {
       expect(invertAndReverseMorse('. .- --. -')).toBe('EDAT');
+    });
+  });
+
+  describe('encodeMorse', () => {
+    it('SOS', () => {
+      expect(encodeMorse('SOS')).toBe('... --- ...');
+    });
+
+    it('multi-word', () => {
+      expect(encodeMorse('HELLO WORLD')).toBe(
+        '.... . .-.. .-.. ---/.-- --- .-. .-.. -..',
+      );
+    });
+
+    it('unknown character becomes ?', () => {
+      expect(encodeMorse('A~B')).toBe('.- ? -...');
+    });
+
+    it('round-trips with decodeMorse', () => {
+      const original = 'THE QUICK BROWN FOX';
+      expect(decodeMorse(encodeMorse(original))).toBe(original);
+    });
+
+    it('custom dividers', () => {
+      expect(encodeMorse('SOS', '|', '+')).toBe('...|---|...');
     });
   });
 

--- a/test/pigpen.ts
+++ b/test/pigpen.ts
@@ -2,6 +2,7 @@ import {describe, it, expect} from 'vitest';
 import {
   canTogglePigpenSegment,
   decodePigpenStream,
+  encodePigpenStream,
   hasPigpenSegment,
   isCardinal,
   isIntercardinal,
@@ -262,6 +263,35 @@ describe('Pigpen', () => {
 
     it('returns empty for empty stream', () => {
       expect(decodePigpenStream([])).toBe('');
+    });
+  });
+
+  describe('encodePigpenStream', () => {
+    it('basic encoding', () => {
+      expect(encodePigpenStream('ABC')).toEqual([
+        PigpenEncoding.LetterA,
+        PigpenEncoding.LetterB,
+        PigpenEncoding.LetterC,
+      ]);
+    });
+
+    it('unknown character becomes None', () => {
+      expect(encodePigpenStream('A1B')).toEqual([
+        PigpenEncoding.LetterA,
+        PigpenEncoding.None,
+        PigpenEncoding.LetterB,
+      ]);
+    });
+
+    it('round-trips with decodePigpenStream', () => {
+      const original = [
+        PigpenEncoding.LetterH,
+        PigpenEncoding.LetterE,
+        PigpenEncoding.LetterL,
+        PigpenEncoding.LetterL,
+        PigpenEncoding.LetterO,
+      ];
+      expect(encodePigpenStream(decodePigpenStream(original))).toEqual(original);
     });
   });
 

--- a/test/pigpen.ts
+++ b/test/pigpen.ts
@@ -291,7 +291,9 @@ describe('Pigpen', () => {
         PigpenEncoding.LetterL,
         PigpenEncoding.LetterO,
       ];
-      expect(encodePigpenStream(decodePigpenStream(original))).toEqual(original);
+      expect(encodePigpenStream(decodePigpenStream(original))).toEqual(
+        original,
+      );
     });
   });
 

--- a/test/semaphore.ts
+++ b/test/semaphore.ts
@@ -2,6 +2,7 @@ import {describe, it, expect} from 'vitest';
 import {
   addSemaphoreDirection,
   decodeSemaphoreStream,
+  encodeSemaphoreStream,
   degreesToSemaphoreDirection,
   directionsToEncoding,
   getEncodingDegrees,
@@ -188,6 +189,22 @@ describe('Semaphore', () => {
         SemaphoreEncoding.LetterB,
       ]);
       expect(result).toBe('A B');
+    });
+
+    it('encodeSemaphoreStream basic', () => {
+      expect(encodeSemaphoreStream('ABC')).toEqual([
+        SemaphoreEncoding.LetterA,
+        SemaphoreEncoding.LetterB,
+        SemaphoreEncoding.LetterC,
+      ]);
+    });
+
+    it('encodeSemaphoreStream unknown character becomes None', () => {
+      expect(encodeSemaphoreStream('A~B')).toEqual([
+        SemaphoreEncoding.LetterA,
+        SemaphoreEncoding.None,
+        SemaphoreEncoding.LetterB,
+      ]);
     });
 
     it('decodeSemaphoreStream with number mode', () => {


### PR DESCRIPTION
Each symbol-encoding module previously only supported the decode direction (encoded representation → plain text). This adds the reverse: given plain text, produce the encoded representation.

New functions:
- encodeMorse(text, charDiv?, wordDiv?) → dot/dash string e.g. encodeMorse('SOS') → '... --- ...' Unknown characters produce '?' consistent with decodeMorseChar.

- encodeBrailleStream(text) → BrailleEncoding[] Unknown characters map to BrailleEncoding.None.

- encodePigpenStream(text) → PigpenEncoding[] Unknown characters map to PigpenEncoding.None.

- encodeSemaphoreStream(text) → SemaphoreEncoding[] Unknown characters map to SemaphoreEncoding.None.

All functions uppercase the input before lookup, matching the existing ENTRIES tables which store display values as uppercase.